### PR TITLE
These changes might fix the issue in link state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,6 @@ const inMemoryCache = new InMemoryCache();
 const stateLink = withClientState({
   cache: inMemoryCache,
   resolvers: {
-    Query: () => ({}),
     Mutation: {
       addUserId: (_, { userId }, { cache }) => {
         const data = {
@@ -32,7 +31,8 @@ const stateLink = withClientState({
         };
         cache.writeData({
           data,
-        });
+          __typename:'getUserId' // Typename is required for cache key
+         });
         return null;
       },
     },

--- a/src/routes/CheckToken.js
+++ b/src/routes/CheckToken.js
@@ -22,7 +22,7 @@ class CheckToken extends React.Component {
 
     const { refreshToken: { token: newToken, userId } } = response.data;
     await AsyncStorage.setItem(TOKEN_KEY, newToken);
-    await this.props.addUserId({ variables: { userId } });
+    await this.props.addUserId({ variables: { getUserId: userId } });
     this.props.history.push('/products');
   };
 

--- a/src/routes/Products.js
+++ b/src/routes/Products.js
@@ -65,16 +65,16 @@ const Products = ({ data: { products, getUserId }, loading, history }) => {
 
 export const productsQuery = gql`
   {
-    # products {
-    #   id
-    #   price
-    #   pictureUrl
-    #   name
-    #   seller {
-    #     id
-    #   }
-    # }
-    getUserId
+     products {
+       id
+       price
+       pictureUrl
+       name
+       seller {
+         id
+       }
+     }
+    getUserId @client
   }
 `;
 


### PR DESCRIPTION
I cant really test out my changes as I was unable to boot up the prisma cluster but I think this should fix the deal.

Problems that are fixed:
1. There were no __tyname in mutation which is required for cache keys
2. In mutation variables names were messed up

I have written a blog on apollo-link-state that have a working example and is similar to your.
Check it out https://hptechblogs.com/central-state-management-in-apollo-using-apollo-link-state/